### PR TITLE
World Building: Reducing example aspects

### DIFF
--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -1,5 +1,6 @@
 # Introduction
 
+<!-- TODO: Tighten this up. -->
 **MiniFate** is a roleplaying game that allows the players to tell a
 collaborative story. It has just enough rules to help the group decide what
 happens while staying out of the way of the narrative. It is based on [_Fate

--- a/chapters/02-world-building.md
+++ b/chapters/02-world-building.md
@@ -14,33 +14,34 @@ PCs, using their creation to find out more details of the setting.
 ## Setting
 
 To start, decide what kind of setting you want for your story. Then work
-together to write down some aspects. This way, you know everyone is on the
-same page about important themes and conflicts. For example:
+together to write down the aspects. This way, you know everyone is on the
+same page about important themes and conflicts.
 
-<!-- TODO: Can we cut this down to Genre, Tech/Magic, Conflicts? -->
-<!-- TODO: Point out every game needs a conflict. Are their prescribed aspects
-for worlds? Setting and Conflict?-->
+Don't worry about getting the Aspects perfect because you will update these
+Aspects later in response to changes in the narrative. As long as everyone has
+a good sense of what belongs in the setting and what doesn't you're ready to
+go.
 
-**Genre**:
+Your setting will have two Aspects: the Genre and the Conflict.
 
-- \aspect{Mega Tokyo After the Bomb Dropped}
-- \aspect{Mirror shades, trench coats, hacking, and lots of guns}
+### Genre
 
-**Conflicts**: 
+The Genre is the one sentence summary of your setting. It is big picture:
+where, when, and what. For example: 
 
-- \aspect{Plucky Rebels Take On A Galaxy-spanning Empire}
+- \aspect{Mega Tokyo After The Bomb Dropped}
+- \aspect{Mirror shades, trench coats, hacking, and lots of guns}.
+- \aspect{High School Where Everyone Has Superpowers}
+
+### Conflict
+
+Your setting's Conflict focuses on the details: the who and the why. Its it
+what drives your PCs to action. For example, 
+
+- \aspect{Galaxy-spanning Empire Tightens Its Grip}
 - \aspect{An Ancient Evil Once Again Threatens the Realms of Men, Dwarves, and
   Elves} 
-
-**Technology or Magic**: 
-
-- \aspect{High School Where Everyone Has Superpowers}
-- \aspect{Cybernetics Let Anyone Improve Themselves for A Price}
-
-Write as many or as few Aspects as you need to define your setting. Everyone
-at the table should have a feel for what belongs, and what doesn't. You can
-always update these Aspects later in response to changes in the
-narrative---even if your scene is already underway!
+- \aspect{Machines Enslaved Us After the First War}
 
 ## Scenes
 

--- a/chapters/02-world-building.md
+++ b/chapters/02-world-building.md
@@ -1,7 +1,5 @@
 # World Building
 
-<!-- Are setting and scene capitalized? -->
-
 In MiniFate, character creation and setting creation happen together. Players
 and the GM may show up to the first session with rough ideas, but ultimately
 settings are defined by their characters and vice versa. A \aspect{Pirate
@@ -23,15 +21,21 @@ same page about important themes and conflicts. For example:
 <!-- TODO: Point out every game needs a conflict. Are their prescribed aspects
 for worlds? Setting and Conflict?-->
 
-- _Conflicts_: \aspect{Plucky Rebels Take On A Galaxy-spanning Empire} or
-  \aspect{An Ancient Evil Once Again Threatens the Realms of Men, Dwarves, and
+**Genre**:
+
+- \aspect{Mega Tokyo After the Bomb Dropped}
+- \aspect{Mirror shades, trench coats, hacking, and lots of guns}
+
+**Conflicts**: 
+
+- \aspect{Plucky Rebels Take On A Galaxy-spanning Empire}
+- \aspect{An Ancient Evil Once Again Threatens the Realms of Men, Dwarves, and
   Elves} 
-- _Technology or Magic_: \aspect{High School Where Everyone Has Superpowers}
-  or \aspect{Cybernetics Let Anyone Improve Themselves for A Price}
-- _Themes_: \aspect{Humanity Fights for Survival in the Far Future} or
-  \aspect{The Mob Runs This Town}.
-- _Groups_: \aspect{Starship Crew Boldly Explores the Galaxy} or \aspect{
-  Shadowy Government Agency Hides Magic from Normal People}
+
+**Technology or Magic**: 
+
+- \aspect{High School Where Everyone Has Superpowers}
+- \aspect{Cybernetics Let Anyone Improve Themselves for A Price}
 
 Write as many or as few Aspects as you need to define your setting. Everyone
 at the table should have a feel for what belongs, and what doesn't. You can
@@ -41,7 +45,7 @@ narrative---even if your scene is already underway!
 ## Scenes
 
 Your game will take place across a number of scenes that exist within the
-larger Setting. Just as with your overall setting, each scene will have one or
+larger setting. Just as with your overall setting, each scene will have one or
 more Aspects that describes it.
 
 The GM will often create these Aspects as they describe the scene to the
@@ -49,6 +53,6 @@ players. Some examples: \aspect{Alien Bar Where The Authorities Dare Not
 Tread}, \aspect{Mob's Docks At Midnight}, or \aspect{Ancient Fortification
 Surrounded by Orcs}.
 
-Just as with Setting Aspects, don't be shy about updating Scene Aspects if the
+Just as with setting Aspects, don't be shy about updating Scene Aspects if the
 story calls for it. Remember: aspects are always true! <!-- TODO: I don't
 think we've ever said this before.-->

--- a/chapters/02-world-building.md
+++ b/chapters/02-world-building.md
@@ -23,8 +23,9 @@ same page about important themes and conflicts. For example:
 <!-- TODO: Point out every game needs a conflict. Are their prescribed aspects
 for worlds? Setting and Conflict?-->
 
-- _Conflicts_: \aspect{Plucky Take On A Galaxy-spanning Empire} or \aspect{An
-  Ancient Evil Once Again Threatens the Realms of Men, Dwarves, and Elves} 
+- _Conflicts_: \aspect{Plucky Rebels Take On A Galaxy-spanning Empire} or
+  \aspect{An Ancient Evil Once Again Threatens the Realms of Men, Dwarves, and
+  Elves} 
 - _Technology or Magic_: \aspect{High School Where Everyone Has Superpowers}
   or \aspect{Cybernetics Let Anyone Improve Themselves for A Price}
 - _Themes_: \aspect{Humanity Fights for Survival in the Far Future} or


### PR DESCRIPTION
Two questions I want to answer in this PR:

1. Can we reduce the example aspects to three sets (Genre, Conflicts, Tech/Magic)? Do we do two or three per?
2. Should we prescribe aspects? I hate to do this for scenes, because they come up a lot, but saying "Pick a Genre Aspect" and "Pick a conflict aspect" and "Then fill in whatever else you need." doesn't seem too heavy for a one-time thing.