### PR TITLE
box around quote, margin tweaks

### DIFF
--- a/chapters/00-header.md
+++ b/chapters/00-header.md
@@ -19,7 +19,6 @@ header-includes: |
   \usepackage{include/dice}
   \usepackage[flushmargin,side]{footmisc}
   \usepackage{tcolorbox}
-  \usepackage{framed}
 ---
 
 \newcommand{\aspect}[1]{\textsc{\lowercase{#1}}}

--- a/chapters/00-header.md
+++ b/chapters/00-header.md
@@ -19,13 +19,19 @@ header-includes: |
   \usepackage{include/dice}
   \usepackage[flushmargin,side]{footmisc}
   \usepackage{tcolorbox}
+  \usepackage{framed}
 ---
 
-\newcommand{\aspect}[1]{\textsc{#1}}
+\newcommand{\aspect}[1]{\textsc{\lowercase{#1}}}
 \newcommand{\skill}[1]{\textit{#1}}
 \newcommand{\keyword}[1]{\textbf{#1}}
 
 \newcommand{\roll}[1]{\foreach \val in {#1}{\ifthenelse{\equal{\val}{+}}{\die+}{\ifthenelse{\equal{\val}{-}}{\die-}{\die{}}}\;}}
+
+<!---
+Use a color box for block quotes
+-->
+\renewenvironment{quote}{\begin{tcolorbox}[colframe=black, colback=white]}{\end{tcolorbox}}
 
 <!---
 Redefine how footnotes are drawn. No number, and draw a box around the text.
@@ -35,7 +41,7 @@ Redefine how footnotes are drawn. No number, and draw a box around the text.
 \renewcommand\@makefntext[1]{%
     \noindent
     \tcbox[colback=white,colframe=black,size=small]{
-        \begin{minipage}{\marginparwidth}#1\end{minipage}}}
+        \begin{minipage}{\marginparwidth}\raggedright#1\end{minipage}}}
 \makeatother
 
 <!---

--- a/chapters/02-world-building.md
+++ b/chapters/02-world-building.md
@@ -45,12 +45,6 @@ For example, these aspects could set the stage for a sweeping fantasy epic:
  Conflict \aspect{Galaxy-Spanning Empire Tightens its Grip}
 --------- --------------------------------------------------------
 
-
-<table width=100%><tbody>
-<tr><td>Genre</td><td>\aspect{Outlaws and Prophecies on the Outer Planets}</td></tr>
-<tr><td>Conflict</td><td>\aspect{Galaxy-Spanning Empire Tightens its Grip}</td></tr>
-</tbody></table>
-
 <!---
 TODO:
 The above are examples to help you wrap your head around the idea. From here on, we'll be using:

--- a/chapters/02-world-building.md
+++ b/chapters/02-world-building.md
@@ -26,18 +26,30 @@ space travel, both, or neither.
 
 For example, these aspects could set the stage for a sweeping fantasy epic:
 
-- Genre: \aspect{Magic Fades at the Dawn of the Age of Men}
-- Conflict: \aspect{Ancient Evil Returns After Millennia}
+--------- --------------------------------------------------------
+    Genre \aspect{Magic Fades at the Dawn of the Age of Men}
+ Conflict \aspect{Ancient Evil Returns After Millennia}
+--------- --------------------------------------------------------
 
 ...or a hyper-violent technological thriller:
 
-- Genre: \aspect{Computers, Guns, and Mirror Shades}
-- Conflict: \aspect{Machines Enslaved Humanity After the First War}
+--------- --------------------------------------------------------
+    Genre \aspect{Computers, Guns, and Mirror Shades}
+ Conflict \aspect{Machines Enslaved Humanity After the First War}
+--------- --------------------------------------------------------
 
 ...or even a space opera with cowboys and swordfights:
 
-- Genre: \aspect{Outlaws and Prophecies on the Outer Planets}
-- Conflict: \aspect{Galaxy-Spanning Empire Tightens its Grip}
+--------- --------------------------------------------------------
+    Genre \aspect{Outlaws and Prophecies on the Outer Planets}
+ Conflict \aspect{Galaxy-Spanning Empire Tightens its Grip}
+--------- --------------------------------------------------------
+
+
+<table width=100%><tbody>
+<tr><td>Genre</td><td>\aspect{Outlaws and Prophecies on the Outer Planets}</td></tr>
+<tr><td>Conflict</td><td>\aspect{Galaxy-Spanning Empire Tightens its Grip}</td></tr>
+</tbody></table>
 
 <!---
 TODO:


### PR DESCRIPTION
![Screen Shot 2020-12-29 at 4 27 40 PM](https://user-images.githubusercontent.com/6157403/103318107-f8cc8b80-49f2-11eb-8c9a-65937ee40537.png)

Lowercase small caps on aspects for improved legibility

Ragged wrap on footnotes. Justified text gets weird due to narrow width

Moved example settings to tables, though unfortunately they are not uniformly wide. I still like this better?

Blockquote environment now uses a tcolorbox, similar to footnotes. Easy to configure spacing, border, shading from here