### PR TITLE
Force bundle update after install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -y update \
 ADD Gemfile .
 RUN gem install bundler \
     && gem update --system \
-    && bundle install
+    && bundle install \
+    && bundle update  # This prevents Bug #39, would love to remove it
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
This fixes #39, but I have not idea *WHY* we have to do an update
immediately after and install. 🤷 