### PR TITLE
Prevent breaking between die images and Punctuation

### DIFF
--- a/_chapters/01-introduction.md
+++ b/_chapters/01-introduction.md
@@ -76,7 +76,9 @@ on two sides, {{zero}} on two sides, and {{neg}} on two sides. Each roll uses
 four dice. To keep things moving quickly, it's best to have four dice for each
 player rather than passing them back and forth. If you don't have specially
 marked Fate dice, you can use a normal six-side die and treat 1 and 2 as
-{{neg}}, 3 and 4 as {{zero}}, and 5 and 6 as {{pos}}.
+<span class="nowrap">{{neg}},</span> 3 and 4 as <span
+class="nowrap">{{zero}},</span> and 5 and 6 as <span
+class="nowrap">{{pos}}.</span>
 
 Finally, you'll need a way to keep track of fate points. It's possible to
 track them with tick marks on your character sheet, but much more satisfying

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -56,3 +56,7 @@ img.die {
   width: $dice-size;
   vertical-align: middle;
 }
+
+span.nowrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
I don't see a away to do this without hardcoding, except via running JS
which seems like overkill.

Before:

![before](https://user-images.githubusercontent.com/4562016/103960115-51440d00-5106-11eb-8714-8cd7982a8b74.png)

After:

![after](https://user-images.githubusercontent.com/4562016/103960128-54d79400-5106-11eb-8e87-86a9c98bb157.png)
