### PR TITLE
Add CSS for blockquote

### DIFF
--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -60,3 +60,11 @@ img.die {
 span.nowrap {
   white-space: nowrap;
 }
+
+// Example gameplay uses blockquotes
+blockquote {
+  background: #f9f9f9;
+  border-left: 10px solid #ccc;
+  margin: 1.5em 10px;
+  padding: 0.5em 10px;
+}

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -63,8 +63,7 @@ span.nowrap {
 
 // Example gameplay uses blockquotes
 blockquote {
-  background: #f9f9f9;
-  border-left: 10px solid #ccc;
-  margin: 1.5em 10px;
-  padding: 0.5em 10px;
+  border-left: 0.4em solid grey;
+  margin: 0.5em 0 0.5em 2em;
+  padding: 0 0.5em;
 }


### PR DESCRIPTION
We can mess with this some still.

# Before:

![before](https://user-images.githubusercontent.com/4562016/104548285-56f99100-55e5-11eb-83a8-c530fda6137b.png)

# After:

![after](https://user-images.githubusercontent.com/4562016/104548291-59f48180-55e5-11eb-812b-96d85b5b3b29.png)
