### PR TITLE
"Write" dice SVGs instead of "Drawing" them

### DIFF
--- a/images/minus.svg
+++ b/images/minus.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
 <mask id="remove_middle">
  <rect id="all" width="100%" height="100%" fill="white"/>
- <rect id="middle" x="7.5" y="7.5" width="85" height="85" rx="14.45" fill="black"/>
+ <rect id="middle" x="5" y="5" width="90" height="90" rx="14.45" fill="black"/>
 </mask>
  <rect id="border" width="100" height="100" rx="17" fill="black" mask="url(#remove_middle)"/>
- <line id="horizontal" x1="20" y1="50" x2="80" y2="50" stroke="black" stroke-width="10" stroke-linecap="butt"/>
+ <line id="horizontal" x1="20" y1="50" x2="80" y2="50" stroke="black" stroke-width="7.5" stroke-linecap="butt"/>
 </svg>

--- a/images/minus.svg
+++ b/images/minus.svg
@@ -1,71 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="100mm"
-   height="100mm"
-   viewBox="0 0 100 100"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="minus.svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.2851563"
-     inkscape:cx="-111.79961"
-     inkscape:cy="156.80727"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="3738"
-     inkscape:window-height="2063"
-     inkscape:window-x="3942"
-     inkscape:window-y="41"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-197)">
-    <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect4522"
-       width="89.762108"
-       height="89.762108"
-       x="5.1189461"
-       y="202.11894"
-       rx="14.298931"
-       ry="14.298931" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 20.375164,247 H 79.624836"
-       id="path4547"
-       inkscape:connector-curvature="0" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<mask id="remove_middle">
+ <rect id="all" width="100%" height="100%" fill="white"/>
+ <rect id="middle" x="7.5" y="7.5" width="85" height="85" rx="14.45" fill="black"/>
+</mask>
+ <rect id="border" width="100" height="100" rx="17" fill="black" mask="url(#remove_middle)"/>
+ <line id="horizontal" x1="20" y1="50" x2="80" y2="50" stroke="black" stroke-width="10" stroke-linecap="butt"/>
 </svg>

--- a/images/plus.svg
+++ b/images/plus.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
 <mask id="remove_middle">
  <rect id="all" width="100%" height="100%" fill="white"/>
- <rect id="middle" x="7.5" y="7.5" width="85" height="85" rx="14.45" fill="black"/>
+ <rect id="middle" x="5" y="5" width="90" height="90" rx="14.45" fill="black"/>
 </mask>
  <rect id="border" width="100" height="100" rx="17" fill="black" mask="url(#remove_middle)"/>
- <line id="vertical" x1="50" y1="20" x2="50" y2="80" stroke="black" stroke-width="10" stroke-linecap="butt"/>
- <line id="horizontal" x1="20" y1="50" x2="80" y2="50" stroke="black" stroke-width="10" stroke-linecap="butt"/>
+ <line id="vertical" x1="50" y1="20" x2="50" y2="80" stroke="black" stroke-width="7.5" stroke-linecap="butt"/>
+ <line id="horizontal" x1="20" y1="50" x2="80" y2="50" stroke="black" stroke-width="7.5" stroke-linecap="butt"/>
 </svg>

--- a/images/plus.svg
+++ b/images/plus.svg
@@ -1,76 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="100mm"
-   height="100mm"
-   viewBox="0 0 100 100"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="plus.svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.2851563"
-     inkscape:cx="-111.79961"
-     inkscape:cy="156.80727"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="3738"
-     inkscape:window-height="2063"
-     inkscape:window-x="3942"
-     inkscape:window-y="41"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-197)">
-    <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect4522"
-       width="89.762108"
-       height="89.762108"
-       x="5.1189461"
-       y="202.11894"
-       rx="14.298931"
-       ry="14.298931" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 20.375164,247 H 79.624836"
-       id="path4547"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 50,276.62484 V 217.37516"
-       id="path4547-3"
-       inkscape:connector-curvature="0" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<mask id="remove_middle">
+ <rect id="all" width="100%" height="100%" fill="white"/>
+ <rect id="middle" x="7.5" y="7.5" width="85" height="85" rx="14.45" fill="black"/>
+</mask>
+ <rect id="border" width="100" height="100" rx="17" fill="black" mask="url(#remove_middle)"/>
+ <line id="vertical" x1="50" y1="20" x2="50" y2="80" stroke="black" stroke-width="10" stroke-linecap="butt"/>
+ <line id="horizontal" x1="20" y1="50" x2="80" y2="50" stroke="black" stroke-width="10" stroke-linecap="butt"/>
 </svg>

--- a/images/zero.svg
+++ b/images/zero.svg
@@ -1,66 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="100mm"
-   height="100mm"
-   viewBox="0 0 100 100"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="zero.svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.8174854"
-     inkscape:cx="91.056437"
-     inkscape:cy="185.78514"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="3738"
-     inkscape:window-height="2063"
-     inkscape:window-x="3942"
-     inkscape:window-y="41"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-197)">
-    <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="rect4522"
-       width="89.762108"
-       height="89.762108"
-       x="5.1189461"
-       y="202.11894"
-       rx="14.298931"
-       ry="14.298931" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<mask id="remove_middle">
+ <rect id="all" width="100%" height="100%" fill="white"/>
+ <rect id="middle" x="7.5" y="7.5" width="85" height="85" rx="14.45" fill="black"/>
+</mask>
+ <rect id="border" width="100" height="100" rx="17" fill="black" mask="url(#remove_middle)"/>
 </svg>

--- a/images/zero.svg
+++ b/images/zero.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
 <mask id="remove_middle">
  <rect id="all" width="100%" height="100%" fill="white"/>
- <rect id="middle" x="7.5" y="7.5" width="85" height="85" rx="14.45" fill="black"/>
+ <rect id="middle" x="5" y="5" width="90" height="90" rx="14.45" fill="black"/>
 </mask>
  <rect id="border" width="100" height="100" rx="17" fill="black" mask="url(#remove_middle)"/>
 </svg>


### PR DESCRIPTION
SVGs are just text, so we can "write" them more efficiently than we can "draw" them. They're now:

- Smaller
- Easier to edit
- Style-able via CSS
- Inline-able

## Before

![before](https://user-images.githubusercontent.com/4562016/105943179-94164800-6015-11eb-82c2-2af9877a275f.png)

## After 

![after](https://user-images.githubusercontent.com/4562016/105943186-99739280-6015-11eb-9cd5-290e5d0c7d87.png)
