### PR TITLE
Update dockerfile with explicit ruby, bundler versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
-FROM alpine:3.13
-RUN apk add --update ruby
-RUN apk add \
-    build-base \
-    ruby-dev \
-    libffi-dev \
-    ruby-etc \
-    zlib-dev
+FROM ruby:2
 
-RUN gem install bundler
+RUN gem install bundler -v 2.4.22
 ENV BUNDLE_GEMFILE=/tmp/Gemfile
 COPY Gemfile $BUNDLE_GEMFILE
 RUN bundle install -j 4

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,11 +4,26 @@ layout: substitute
 
 <!DOCTYPE html>
 <html lang="en">
-  {% include head.html %}
-  <body>
-    <main role="main">
-      {% include anchor_headings.html h_min=2 html=content anchorBody="<svg
-        class='anchor-link-img' viewBox='0 0 16 16' version='1.1' width='16' height='32' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>" %}
-    </main>
-  </body>
+{% include head.html %}
+
+<body>
+
+  <main role="main">
+
+    <div class="debug">
+      <p>Jekyll version: {{ site.github.versions.jekyll }}</p>
+      <p>Liquid version: {{ site.github.versions.liquid }}</p>
+      <p>Jekyll environment: {{ jekyll.environment }}</p>
+    </div>
+
+    {% include anchor_headings.html h_min=2 html=content anchorBody="<svg class='anchor-link-img' viewBox='0 0 16 16'
+      version='1.1' width='16' height='32' aria-hidden='true'>
+      <path fill-rule='evenodd'
+        d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'>
+      </path>
+    </svg>" %}
+  </main>
+
+</body>
+
 </html>

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -56,6 +56,10 @@ main {
   padding: 0;
 }
 
+.debug {
+  border: 1px solid red;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: $sans-font-family;
   margin-top: 1.5em;


### PR DESCRIPTION
The newest version of Bundler requires Ruby 3. This breaks our Docker workflow for local development. 

I first tried bumping up to Ruby 3, but ran into the same problem described [here](https://www.reddit.com/r/Jekyll/comments/18sdsh4/noob_question_on_updated_static_website_generator/). The fix seems to be updating to a newer Jekyll. However, when I try that, I run into version conflicts in Liquid (more info [here](https://github.com/jekyll/jekyll/issues/8535)). 

Easiest way forward is to keep using Ruby 2 for now. Updated the Dockerfile to be explicit about Ruby and Bundler versions rather than using the most recent. 

My guess is that GitHub Pages is doing the same in prod. But it would be nice to confirm. We'll see if I can figure out how to expose versions for the underlying Ruby, Bundler, and/or Jekyll.